### PR TITLE
Try to reuse existing layers on new builds

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -22,6 +22,7 @@ target "comfyui-base" {
     }
     tags      = ["${DOCKER_REGISTRY_URL}comfyui-base:latest"]
     platforms = ["linux/amd64"]
+    cache-from = ["type=registry,ref=${DOCKER_REGISTRY_URL}comfyui-base:latest"]
 }
 
 target "comfyui-extensions" {
@@ -32,6 +33,7 @@ target "comfyui-extensions" {
     }
     tags      = ["${DOCKER_REGISTRY_URL}comfyui-extensions:latest"]
     platforms = ["linux/amd64"]
+    cache-from = ["type=registry,ref=${DOCKER_REGISTRY_URL}comfyui-extensions:latest"]
 }
 
 target "comfyui-omnigen2" {
@@ -42,4 +44,5 @@ target "comfyui-omnigen2" {
     }
     tags       = ["${DOCKER_REGISTRY_URL}comfyui-omnigen2:latest"]
     platforms  = ["linux/amd64"]
+    cache-from = ["type=registry,ref=${DOCKER_REGISTRY_URL}comfyui-omnigen2:latest"]
 }


### PR DESCRIPTION
Reuse prebuilt layers as much as possible to reduce churn.