### PR TITLE
Try to enable omnigen2 again now that the build can be cached

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -10,7 +10,7 @@ variable "COMFYUI_REF" {
 }
 
 group "default" {
-    targets = ["comfyui-base", "comfyui-extensions", "comfyui-reactor"]
+    targets = ["comfyui-base", "comfyui-extensions", "comfyui-omnigen2", "comfyui-reactor"]
 }
 
 target "comfyui-base" {

--- a/dockerfile.omnigen2
+++ b/dockerfile.omnigen2
@@ -9,7 +9,7 @@ RUN --mount=type=cache,target=/cache/pip,sharing=locked \
     . venv/bin/activate && \
     pip install ninja && \
     pip install -r /comfyui/custom_nodes/ComfyUI-OmniGen2/requirements.txt && \
-    MAX_JOBS=2 NVCC_THREADS=2 pip install flash_attn --use-pep517 --no-build-isolation -v && \
+    MAX_JOBS=1 NVCC_THREADS=2 pip install flash_attn --use-pep517 --no-build-isolation -v && \
     rm -rf /tmp/omnigen2.tar.gz
 
 # Add entrypoint script

--- a/dockerfile.omnigen2
+++ b/dockerfile.omnigen2
@@ -9,7 +9,7 @@ RUN --mount=type=cache,target=/cache/pip,sharing=locked \
     . venv/bin/activate && \
     pip install ninja && \
     pip install -r /comfyui/custom_nodes/ComfyUI-OmniGen2/requirements.txt && \
-    MAX_JOBS=1 NVCC_THREADS=1 pip install flash_attn --use-pep517 --no-build-isolation -v && \
+    MAX_JOBS=2 NVCC_THREADS=2 pip install flash_attn --use-pep517 --no-build-isolation -v && \
     rm -rf /tmp/omnigen2.tar.gz
 
 # Add entrypoint script


### PR DESCRIPTION
The build of flash_attn takes several hours, but now we should be able to cache it.