### PR TITLE
Remove invalid image label value

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -26,7 +26,6 @@ jobs:
     uses: ./.github/workflows/build-docker.yml
     with:
       comfyui_ref: "master"
-      image_label: "base"
       bake_target: "base"
     permissions:
       contents: read


### PR DESCRIPTION
The image label is not used when building the "base" target so don't set it.