### PR TITLE
Set a valid image_label when building base images

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -26,6 +26,7 @@ jobs:
     uses: ./.github/workflows/build-docker.yml
     with:
       comfyui_ref: "master"
+      image_label: "master"
       bake_target: "base"
     permissions:
       contents: read


### PR DESCRIPTION
Perhaps it shouldn't be a required value, but its also nice to not forget to set it..