### PR TITLE
Looks like xformers brought in old pytorch

### DIFF
--- a/dockerfile.nvidia.base
+++ b/dockerfile.nvidia.base
@@ -38,8 +38,7 @@ RUN --mount=type=cache,target=/cache/uv,sharing=locked \
     transformers \
     accelerate \
     sentencepiece \
-    protobuf \
-    xformers
+    protobuf
 
 # Install our pre-built SageAttention wheel
 COPY --from=builder /comfyui/SageAttention/dist /tmp/wheels


### PR DESCRIPTION
Installing the existing xformers wheel replaced our PyTorch with 2.7.1 - drop it for now, will have to build it from source.