### PR TITLE
Don't set the sha as the ref

### DIFF
--- a/.github/workflows/check-comfyui.yml
+++ b/.github/workflows/check-comfyui.yml
@@ -63,7 +63,7 @@ jobs:
       cancel-in-progress: false
     uses: ./.github/workflows/build-docker.yml
     with:
-      comfyui_ref: "${{ needs.check-comfyui.outputs.comfyui_sha }}"
+      comfyui_ref: "${{ inputs.comfyui_ref }}"
       image_label: "${{ inputs.image_label }}"
     permissions:
       contents: read


### PR DESCRIPTION
This causes the first change to succeed but any later one will fail as the image labels are wrong.