### PR TITLE
Fix manager first-run errors

### DIFF
--- a/dockerfile.extensions
+++ b/dockerfile.extensions
@@ -16,9 +16,14 @@ RUN git clone --depth 1 --bare --branch ${COMFYUI_VERSION} \
 # Required by ComfyUI-Manager
 ENV COMFYUI_PATH=/comfyui
 
-# Download and configure ComfyUI-Manager outside of the ComfyUI directory
+# Download ComfyUI-Manager outside of the ComfyUI directory
+RUN git clone --depth 1 https://github.com/ltdrdata/ComfyUI-Manager /comfyui-manager
+
+# Install a base set of overrides to avoid errors at first lauch
+COPY pip_overrides.json /comfyui-manager/pip_overrides.json
+
+# Install ComfyUI-Manager requirements and run update
 RUN --mount=type=cache,target=/cache/uv,sharing=locked \
-    git clone --depth 1 https://github.com/ltdrdata/ComfyUI-Manager /comfyui-manager && \
     . venv/bin/activate && \
     uv pip install -r /comfyui-manager/requirements.txt && \
     python /comfyui-manager/cm-cli.py update all

--- a/pip_overrides.json
+++ b/pip_overrides.json
@@ -1,0 +1,7 @@
+{
+    "opencv-python": "opencv-contrib-python-headless",
+    "opencv-python-headless": "opencv-contrib-python-headless",
+    "opencv-contrib-python": "opencv-contrib-python-headless",
+    "huggingface_hub": "huggingface-hub",
+    "segment_anything": "segment-anything"
+}


### PR DESCRIPTION
When starting fresh, this error appears when installing nodes:

`File "/comfyui/custom_nodes/ComfyUI-Manager/glob/manager_core.py", line 264, in remap_pip_package if pkg in cm_global.pip_overrides: ^^^^^^^^^^^^^^^^^^^^^^^ AttributeError: module 'cm_global' has no attribute 'pip_overrides'`

