### PR TITLE
Avoid conflicting pushes from PRs

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -35,38 +35,28 @@ jobs:
       image_label: ${{ inputs.image_label }}
       bake_target: ${{ inputs.bake_target }}
       push_images: ${{ inputs.push_images }}
+    secrets: inherit
 
   build:
     needs: [build-nvidia-builders]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     strategy:
       fail-fast: false
       matrix:
         base_flavor: [nvidia, cpu, amd]
-    env:
-      BASE_FLAVOR: ${{ matrix.base_flavor }}
-      SSH_HOST_ED25519_KEY_B64: ${{ secrets.SSH_HOST_ED25519_KEY_B64 }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build (flavor=${{ matrix.base_flavor }})
-        uses: ./.github/actions/bake-build
-        with:
-          comfyui_ref: ${{ inputs.comfyui_ref }}
-          image_label: ${{ inputs.image_label }}
-          targets: ${{ inputs.bake_target || 'default' }}
-          push: ${{ inputs.push_images && 'true' || 'false' }}
-          registry: ${{ env.REGISTRY }}
-          docker_registry_url: ${{ env.DOCKER_REGISTRY_URL }}
-          registry_token: ${{ secrets.GITHUB_TOKEN }}
-          extra_set: |
-            nvidia-xformers.args.MAX_JOBS=1
-            nvidia-xformers.args.NVCC_THREADS=4
-            nvidia-sageattention.args.MAX_JOBS=1
-            nvidia-sageattention.args.NVCC_THREADS=4
-            nvidia-nunchaku.args.MAX_JOBS=1
-            nvidia-nunchaku.args.NVCC_THREADS=4
-            nvidia-flashattention.args.MAX_JOBS=1
-            nvidia-flashattention.args.NVCC_THREADS=2
+    uses: ./.github/workflows/build-flavor.yml
+    with:
+      comfyui_ref: ${{ inputs.comfyui_ref }}
+      image_label: ${{ inputs.image_label }}
+      base_flavor: ${{ matrix.base_flavor }}
+      targets: ${{ inputs.bake_target || 'default' }}
+      push_images: ${{ inputs.push_images }}
+      extra_set: |
+        nvidia-xformers.args.MAX_JOBS=1
+        nvidia-xformers.args.NVCC_THREADS=4
+        nvidia-sageattention.args.MAX_JOBS=1
+        nvidia-sageattention.args.NVCC_THREADS=4
+        nvidia-nunchaku.args.MAX_JOBS=1
+        nvidia-nunchaku.args.NVCC_THREADS=4
+        nvidia-flashattention.args.MAX_JOBS=1
+        nvidia-flashattention.args.NVCC_THREADS=2
+    secrets: inherit

--- a/.github/workflows/build-flavor.yml
+++ b/.github/workflows/build-flavor.yml
@@ -1,0 +1,56 @@
+name: Build Docker flavor
+
+on:
+  workflow_call:
+    inputs:
+      comfyui_ref:
+        description: "ComfyUI branch or tag to build from"
+        required: true
+        type: string
+      image_label:
+        description: "Label to apply to the built image"
+        required: true
+        type: string
+      base_flavor:
+        description: "Base flavor to build"
+        required: true
+        type: string
+      targets:
+        description: "Docker Bake target or group to build"
+        required: true
+        type: string
+      push_images:
+        description: "Whether built images should be pushed to the registry"
+        required: true
+        type: boolean
+      extra_set:
+        description: "Additional Bake set lines (optional)"
+        required: false
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      DOCKER_REGISTRY_URL: ghcr.io/${{ github.repository_owner }}/
+      IMAGE_LABEL: ${{ inputs.image_label }}
+      COMFYUI_VERSION: ${{ inputs.comfyui_ref }}
+      BASE_FLAVOR: ${{ inputs.base_flavor }}
+      SSH_HOST_ED25519_KEY_B64: ${{ secrets.SSH_HOST_ED25519_KEY_B64 }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build (flavor=${{ inputs.base_flavor }})
+        uses: ./.github/actions/bake-build
+        with:
+          comfyui_ref: ${{ inputs.comfyui_ref }}
+          image_label: ${{ inputs.image_label }}
+          targets: ${{ inputs.targets }}
+          push: ${{ inputs.push_images && 'true' || 'false' }}
+          registry: ${{ env.REGISTRY }}
+          docker_registry_url: ${{ env.DOCKER_REGISTRY_URL }}
+          registry_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_set: ${{ inputs.extra_set }}

--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -5,13 +5,27 @@ on:
     branches: [main]
 
 jobs:
-  build-pull-request:
-    uses: ./.github/workflows/build-docker.yml
+  build-pull-request-nvidia:
+    uses: ./.github/workflows/build-nvidia.yml
     with:
       comfyui_ref: "master"
       image_label: "master"
-      push_images: true
+      push_images: false
     permissions:
       contents: read
       packages: write
+    secrets: inherit
+
+  build-pull-request-base-flavors:
+    strategy:
+      fail-fast: false
+      matrix:
+        base_flavor: [cpu, amd]
+    uses: ./.github/workflows/build-flavor.yml
+    with:
+      comfyui_ref: "master"
+      image_label: "master"
+      base_flavor: ${{ matrix.base_flavor }}
+      targets: default
+      push_images: false
     secrets: inherit

--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -21,6 +21,9 @@ jobs:
       fail-fast: false
       matrix:
         base_flavor: [cpu, amd]
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/build-flavor.yml
     with:
       comfyui_ref: "master"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -103,7 +103,7 @@ target "nvidia-sageattention" {
     context = "src"
     dockerfile = "dockerfile.nvidia.sageattention"
     contexts = {
-        builder = "docker-image://${DOCKER_REGISTRY_URL}nvidia-builder:latest"
+        builder = "target:nvidia-builder"
     }
     platforms  = [ "linux/amd64" ]
     tags       = ["${DOCKER_REGISTRY_URL}nvidia-builder:sageattention"]
@@ -115,7 +115,7 @@ target "nvidia-nunchaku" {
     context = "src"
     dockerfile = "dockerfile.nvidia.nunchaku"
     contexts = {
-        builder = "docker-image://${DOCKER_REGISTRY_URL}nvidia-builder:latest"
+        builder = "target:nvidia-builder"
     }
     platforms  = [ "linux/amd64" ]
     tags       = ["${DOCKER_REGISTRY_URL}nvidia-builder:nunchaku"]
@@ -127,7 +127,7 @@ target "nvidia-xformers" {
     context = "src"
     dockerfile = "dockerfile.nvidia.xformers"
     contexts = {
-        builder = "docker-image://${DOCKER_REGISTRY_URL}nvidia-builder:latest"
+        builder = "target:nvidia-builder"
     }
     platforms  = [ "linux/amd64" ]
     tags       = ["${DOCKER_REGISTRY_URL}nvidia-builder:xformers"]
@@ -139,7 +139,7 @@ target "nvidia-flashattention" {
     context = "src"
     dockerfile = "dockerfile.nvidia.flashattention"
     contexts = {
-        builder = "docker-image://${DOCKER_REGISTRY_URL}nvidia-builder:latest"
+        builder = "target:nvidia-builder"
     }
     platforms  = [ "linux/amd64" ]
     tags       = ["${DOCKER_REGISTRY_URL}nvidia-builder:flashattention"]
@@ -151,10 +151,10 @@ target "nvidia-base" {
     context = "src"
     dockerfile = "dockerfile.nvidia.base"
     contexts = {
-        sageattention  = "docker-image://${DOCKER_REGISTRY_URL}nvidia-builder:sageattention"
-        nunchaku       = "docker-image://${DOCKER_REGISTRY_URL}nvidia-builder:nunchaku"
-        xformers       = "docker-image://${DOCKER_REGISTRY_URL}nvidia-builder:xformers"
-        flashattention = "docker-image://${DOCKER_REGISTRY_URL}nvidia-builder:flashattention"
+        sageattention  = "target:nvidia-sageattention"
+        nunchaku       = "target:nvidia-nunchaku"
+        xformers       = "target:nvidia-xformers"
+        flashattention = "target:nvidia-flashattention"
     }
     args = {
         CUDA_RUNTIME_IMAGE  = "${NVIDIA_CUDA_RUNTIME_IMAGE}"
@@ -204,7 +204,7 @@ target "comfyui-base" {
     context    = "src"
     dockerfile = "dockerfile.base"
     contexts = {
-        base = "docker-image://${DOCKER_REGISTRY_URL}comfyui-base:${BASE_FLAVOR}"
+        base = "target:${BASE_FLAVOR}-base"
     }
     args = {
         COMFYUI_VERSION = "${COMFYUI_VERSION}"
@@ -219,7 +219,7 @@ target "comfyui-extensions" {
     context    = "src"
     dockerfile = "dockerfile.extensions"
     contexts = {
-        comfyui-base = "docker-image://${DOCKER_REGISTRY_URL}comfyui-base:${notequal("nvidia", BASE_FLAVOR) ? "${BASE_FLAVOR}-" : ""}${IMAGE_LABEL}"
+        comfyui-base = "target:comfyui-base"
     }
     tags       = ["${DOCKER_REGISTRY_URL}comfyui-extensions:${notequal("nvidia", BASE_FLAVOR) ? "${BASE_FLAVOR}-" : ""}${IMAGE_LABEL}"]
     platforms  = ["linux/amd64"]
@@ -231,7 +231,7 @@ target "comfyui-ssh" {
     context    = "src"
     dockerfile = "dockerfile.ssh"
     contexts = {
-        comfyui-extensions = "docker-image://${DOCKER_REGISTRY_URL}comfyui-extensions:${notequal("nvidia", BASE_FLAVOR) ? "${BASE_FLAVOR}-" : ""}${IMAGE_LABEL}"
+        comfyui-extensions = "target:comfyui-extensions"
     }
     secret     = ["id=SSH_HOST_ED25519_KEY_B64,env=SSH_HOST_ED25519_KEY_B64"]
     tags       = ["${DOCKER_REGISTRY_URL}comfyui-ssh:${notequal("nvidia", BASE_FLAVOR) ? "${BASE_FLAVOR}-" : ""}${IMAGE_LABEL}"]


### PR DESCRIPTION
We can't push tags from PRs as that conflicts with main builds, so we should go back to just relying on caches, and build a little less for NVIDIA in PRs since a base image change would rebuild everything twice otherwise.