### PR TITLE
Switch to uv cache instead of system-installed base packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Additional arguments will be forwarded to ComfyUI. For example, to enable SageAt
 docker run --gpus=all -p 8188:8188 ghcr.io/radiatingreverberations/comfyui-extensions:latest --use-sage-attention
 ```
 
-On first container start, the entrypoint creates `/opt/venv` if it does not already exist. That runtime venv inherits the system packages baked into the base image.
+On container start, the entrypoint creates the runtime virtual environment selected by `VIRTUAL_ENV`, defaulting to `/opt/venv`.
 
 ### With persistent storage
 
@@ -141,7 +141,6 @@ To override them, pass one or more Bake variables such as `CPU_BASE_IMAGE`, `AMD
 ### ComfyUI base image
 
 * [ComfyUI](https://github.com/comfyanonymous/ComfyUI)
-* [HuggingFace CLI](https://huggingface.co/docs/huggingface_hub/guides/cli)
 
 ### ComfyUI extensions image
 

--- a/src/dockerfile.base
+++ b/src/dockerfile.base
@@ -1,31 +1,29 @@
-ARG BASE_IMAGE
+ARG BASE_IMAGE=ghcr.io/offloadr/base/cpu-core:py3.12-torch2.10.0-cpu
 FROM ${BASE_IMAGE}
 
 WORKDIR /comfyui
 
-# Install common dependencies that are typically not ComfyUI version specific
-RUN --mount=type=cache,target=/cache/uv,sharing=locked \
-    uv pip install \
-    --system \
-    --break-system-packages \
-    einops \
-    tokenizers \
-    pyyaml \
-    pillow \
-    scipy \
-    tqdm \
-    psutil \
-    kornia \
-    spandrel \
-    soundfile
+ENV UV_CACHE_DIR=/opt/uv-cache
+ENV UV_LINK_MODE=symlink
+RUN mkdir -p /opt/uv-cache
 
-# Additional dependencies not strictly required by ComfyUI
-RUN --mount=type=cache,target=/cache/uv,sharing=locked \
+# Extend the upstream baked uv cache with common ComfyUI runtime dependencies.
+COPY requirements.cached.txt requirements.cached.txt
+RUN test -n "${OFFLOADR_TORCH_VERSION}" && \
+    test -n "${OFFLOADR_TORCHVISION_VERSION}" && \
+    test -n "${OFFLOADR_TORCH_INDEX_URL}" && \
+    uv venv /tmp/comfyui-cache-venv && \
     uv pip install \
-    --system \
-    --break-system-packages \
-    huggingface_hub[cli] \
-    huggingface_hub[hf_transfer]
+    --python /tmp/comfyui-cache-venv/bin/python \
+    torch==${OFFLOADR_TORCH_VERSION} \
+    torchvision==${OFFLOADR_TORCHVISION_VERSION} \
+    torchaudio==${OFFLOADR_TORCH_VERSION} \
+    --index-url ${OFFLOADR_TORCH_INDEX_URL} && \
+    uv pip install \
+    --python /tmp/comfyui-cache-venv/bin/python \
+    -r requirements.cached.txt && \
+    rm -rf /tmp/comfyui-cache-venv && \
+    chmod -R u+rwX,go+rX,go-w /opt/uv-cache
 
 # Allow cache invalidation of ComfyUI version even if the ref has not changed
 ARG REFRESH_COMFYUI=0
@@ -37,9 +35,26 @@ RUN mkdir -p /comfyui && \
     tar -xzf /tmp/comfyui.tar.gz -C /comfyui --strip-components=1 && \
     rm -rf /tmp/comfyui.tar.gz
 
-# Install remaining ComfyUI version specific dependencies
-RUN --mount=type=cache,target=/cache/uv,sharing=locked \
-    uv pip install --system --break-system-packages -r requirements.txt
+# Extend the upstream baked uv cache with ComfyUI version specific dependencies.
+RUN test -n "${OFFLOADR_TORCH_VERSION}" && \
+    test -n "${OFFLOADR_TORCHVISION_VERSION}" && \
+    test -n "${OFFLOADR_TORCH_INDEX_URL}" && \
+    uv venv /tmp/comfyui-cache-venv && \
+    uv pip install \
+    --python /tmp/comfyui-cache-venv/bin/python \
+    torch==${OFFLOADR_TORCH_VERSION} \
+    torchvision==${OFFLOADR_TORCHVISION_VERSION} \
+    torchaudio==${OFFLOADR_TORCH_VERSION} \
+    --index-url ${OFFLOADR_TORCH_INDEX_URL} && \
+    uv pip freeze --python /tmp/comfyui-cache-venv/bin/python | sort > /tmp/comfyui-torch.freeze && \
+    uv pip install \
+    --python /tmp/comfyui-cache-venv/bin/python \
+    -r requirements.cached.txt \
+    -r requirements.txt && \
+    uv pip freeze --python /tmp/comfyui-cache-venv/bin/python | sort > /tmp/comfyui-full.freeze && \
+    comm -13 /tmp/comfyui-torch.freeze /tmp/comfyui-full.freeze > requirements.lock.txt && \
+    rm -rf /tmp/comfyui-cache-venv /tmp/comfyui-torch.freeze /tmp/comfyui-full.freeze && \
+    chmod -R u+rwX,go+rX,go-w /opt/uv-cache
 
 # ComfyUI defaults to port 8188
 EXPOSE 8188

--- a/src/dockerfile.extensions
+++ b/src/dockerfile.extensions
@@ -10,13 +10,30 @@ RUN apt-get update && \
 # Required by ComfyUI-Manager
 ENV COMFYUI_PATH=/comfyui
 
-# Install optional ComfyUI-Manager dependencies
-RUN --mount=type=cache,target=/cache/uv,sharing=locked \
-    uv pip install --system --break-system-packages matrix-nio
-
-# Install required ComfyUI-Manager dependencies
-RUN --mount=type=cache,target=/cache/uv,sharing=locked \
-    uv pip install --system --break-system-packages -r /comfyui/manager_requirements.txt
+# Extend the upstream baked uv cache with ComfyUI-Manager dependencies.
+RUN test -n "${OFFLOADR_TORCH_VERSION}" && \
+    test -n "${OFFLOADR_TORCHVISION_VERSION}" && \
+    test -n "${OFFLOADR_TORCH_INDEX_URL}" && \
+    uv venv /tmp/comfyui-manager-cache-venv && \
+    uv pip install \
+    --python /tmp/comfyui-manager-cache-venv/bin/python \
+    torch==${OFFLOADR_TORCH_VERSION} \
+    torchvision==${OFFLOADR_TORCHVISION_VERSION} \
+    torchaudio==${OFFLOADR_TORCH_VERSION} \
+    --index-url ${OFFLOADR_TORCH_INDEX_URL} && \
+    uv pip install \
+    --python /tmp/comfyui-manager-cache-venv/bin/python \
+    --no-deps \
+    -r /comfyui/requirements.lock.txt && \
+    uv pip freeze --python /tmp/comfyui-manager-cache-venv/bin/python | sort > /tmp/comfyui-base.freeze && \
+    uv pip install \
+    --python /tmp/comfyui-manager-cache-venv/bin/python \
+    matrix-nio \
+    -r /comfyui/manager_requirements.txt && \
+    uv pip freeze --python /tmp/comfyui-manager-cache-venv/bin/python | sort > /tmp/comfyui-manager.freeze && \
+    comm -13 /tmp/comfyui-base.freeze /tmp/comfyui-manager.freeze > /comfyui/manager_requirements.lock.txt && \
+    rm -rf /tmp/comfyui-manager-cache-venv /tmp/comfyui-base.freeze /tmp/comfyui-manager.freeze && \
+    chmod -R u+rwX,go+rX,go-w /opt/uv-cache
 
 # Add entrypoint script
 COPY entrypoint.extensions.sh entrypoint.extensions.sh

--- a/src/entrypoint.extensions.sh
+++ b/src/entrypoint.extensions.sh
@@ -22,6 +22,10 @@ else:
 		cfg.write(f)
 PYCFG
 
+comfyui_uv_install_cached \
+	--no-deps \
+	-r /comfyui/manager_requirements.lock.txt
+
 # Ensure requirements of custom nodes are installed from the runtime venv.
 python -m cm_cli uv-sync
 

--- a/src/requirements.cached.txt
+++ b/src/requirements.cached.txt
@@ -1,0 +1,12 @@
+einops
+tokenizers
+pyyaml
+pillow
+scipy
+tqdm
+psutil
+kornia
+spandrel
+soundfile
+huggingface_hub
+hf_transfer

--- a/src/runtime-venv.sh
+++ b/src/runtime-venv.sh
@@ -4,8 +4,44 @@ set -e
 VIRTUAL_ENV="${VIRTUAL_ENV:-/opt/venv}"
 export VIRTUAL_ENV
 
-if [ ! -f "${VIRTUAL_ENV}/bin/activate" ]; then
-    uv venv "${VIRTUAL_ENV}" --system-site-packages
+RUNTIME_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+comfyui_uv_install_cached() {
+    uv pip install --python "${VIRTUAL_ENV}/bin/python" "$@"
+}
+
+if [ "${COMFYUI_RUNTIME_VENV_READY:-}" != "${VIRTUAL_ENV}" ]; then
+    : "${OFFLOADR_TORCH_VERSION:?OFFLOADR_TORCH_VERSION must be set by the base image}"
+    : "${OFFLOADR_TORCHVISION_VERSION:?OFFLOADR_TORCHVISION_VERSION must be set by the base image}"
+    : "${OFFLOADR_TORCH_INDEX_URL:?OFFLOADR_TORCH_INDEX_URL must be set by the base image}"
+
+    if [ ! -f "${VIRTUAL_ENV}/bin/activate" ]; then
+        uv venv "${VIRTUAL_ENV}"
+    fi
+
+    # Symlink mode makes startup fast; the venv keeps references into /opt/uv-cache.
+    comfyui_uv_install_cached \
+        torch=="${OFFLOADR_TORCH_VERSION}" \
+        torchvision=="${OFFLOADR_TORCHVISION_VERSION}" \
+        torchaudio=="${OFFLOADR_TORCH_VERSION}" \
+        --index-url "${OFFLOADR_TORCH_INDEX_URL}"
+
+    comfyui_uv_install_cached \
+        --no-deps \
+        -r "${RUNTIME_DIR}/requirements.lock.txt"
+
+    if [ -n "${OFFLOADR_WHEELHOUSE:-}" ] && [ -d "${OFFLOADR_WHEELHOUSE}" ]; then
+        wheel_args=()
+        while IFS= read -r -d '' wheel; do
+            wheel_args+=("${wheel}")
+        done < <(find "${OFFLOADR_WHEELHOUSE}" -maxdepth 1 -type f -name '*.whl' -print0 | sort -z)
+
+        if [ "${#wheel_args[@]}" -gt 0 ]; then
+            comfyui_uv_install_cached "${wheel_args[@]}"
+        fi
+    fi
+
+    export COMFYUI_RUNTIME_VENV_READY="${VIRTUAL_ENV}"
 fi
 
 # Ensure the venv executables are preferred before activation.


### PR DESCRIPTION
Using system-installed packages causes comfyui-manager to think that pytorch isn't installed, and also forced extra downloads of the comfy ui package. Let's try this variant instead to bake all deps in the image.